### PR TITLE
Prebundle framer-motion for Vite

### DIFF
--- a/landing/vite.config.js
+++ b/landing/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    include: ['framer-motion'],
+  },
 })


### PR DESCRIPTION
## Summary
- ensure framer-motion is pre-bundled so Vite can resolve imports

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f5e1b2ea4832c8b72ca34a7ad3b75